### PR TITLE
Fix runtime app name detection for exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ In your `config/config.exs`:
 ```elixir
 config :live_table,
   repo: YourApp.Repo,
-  pubsub: YourApp.PubSub
+  pubsub: YourApp.PubSub,
+  app: :your_app  # Required for exports to work correctly
 
 # Optional: Oban for exports (installer can configure this if you opt in)
 config :your_app, Oban,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,7 @@ Configure LiveTable globally in your `config/config.exs`:
 config :live_table,
   repo: YourApp.Repo,
   pubsub: YourApp.PubSub,
+  app: :your_app,  # Required for exports
   components: YourApp.CustomComponents,  # Optional
   defaults: %{
     pagination: %{
@@ -44,6 +45,7 @@ config :live_table,
 
 - **`repo`** - Your application's Ecto repository
 - **`pubsub`** - Your application's PubSub module for real-time updates
+- **`app`** - Your application's name (atom) - Required for export functionality to work correctly
 
 ### Optional Configuration
 
@@ -590,6 +592,9 @@ Replace LiveTable's default components with your own:
 ```elixir
 # config/config.exs
 config :live_table,
+  repo: YourApp.Repo,
+  pubsub: YourApp.PubSub,
+  app: :your_app,
   components: YourApp.CustomComponents
 ```
 
@@ -645,6 +650,7 @@ Here's a comprehensive configuration example:
 config :live_table,
   repo: YourApp.Repo,
   pubsub: YourApp.PubSub,
+  app: :your_app,
   defaults: %{
     pagination: %{
       enabled: true,
@@ -716,6 +722,7 @@ config :live_table,
 
 - **`repo`** - Your application's Ecto repository
 - **`pubsub`** - Your application's PubSub module for real-time updates
+- **`app`** - Your application's name (atom) - Required for export functionality to work correctly
 
 ### Optional Configuration
 
@@ -1199,6 +1206,9 @@ Replace LiveTable's default components with your own:
 ```elixir
 # config/config.exs
 config :live_table,
+  repo: YourApp.Repo,
+  pubsub: YourApp.PubSub,
+  app: :your_app,
   components: YourApp.CustomComponents
 ```
 
@@ -1254,6 +1264,7 @@ Here's a comprehensive configuration example:
 config :live_table,
   repo: YourApp.Repo,
   pubsub: YourApp.PubSub,
+  app: :your_app,
   defaults: %{
     pagination: %{
       enabled: true,

--- a/lib/live_table/export_helpers.ex
+++ b/lib/live_table/export_helpers.ex
@@ -105,7 +105,7 @@ defmodule LiveTable.ExportHelpers do
 
       @impl true
       def handle_info({:file_ready, file_path}, socket) do
-        app_name = Mix.Project.config()[:app]
+        app_name = Application.fetch_env!(:live_table, :app)
         static_path = Path.join([:code.priv_dir(app_name), "static", "exports"])
         File.mkdir_p!(static_path)
 

--- a/lib/mix/tasks/live_table.install.ex
+++ b/lib/mix/tasks/live_table.install.ex
@@ -59,6 +59,13 @@ defmodule Mix.Tasks.LiveTable.Install do
     repo_module = Module.concat([app_module, "Repo"])
     pubsub_module = Module.concat([app_module, "PubSub"])
 
+    app_atom =
+      app_module
+      |> Module.split()
+      |> List.last()
+      |> Macro.underscore()
+      |> String.to_atom()
+
     has_config? =
       Igniter.Project.Config.configures_root_key?(igniter, "config.exs", :live_table)
 
@@ -70,7 +77,8 @@ defmodule Mix.Tasks.LiveTable.Install do
         config_content = """
         config :live_table,
           repo: #{inspect(repo_module)},
-          pubsub: #{inspect(pubsub_module)}
+          pubsub: #{inspect(pubsub_module)},
+          app: #{inspect(app_atom)}
         """
 
         igniter


### PR DESCRIPTION
## Problem

The current implementation in `export_helpers.ex:108` uses `Mix.Project.config()[:app]` to get the application name at runtime:

```elixir
app_name = Mix.Project.config()[:app]
static_path = Path.join([:code.priv_dir(app_name), "static", "exports"])
```

**Why this is a bug:**
- `Mix.Project.config()` is a build-time tool and should not be used at runtime
- In compiled production releases, Mix is not available, causing runtime failures
- This violates OTP/Elixir best practices for runtime configuration

## Solution

Replace with `Application.fetch_env!(:live_table, :app)` which:
- Works reliably in all deployment scenarios (dev, staging, production, releases)
- Follows OTP conventions for runtime configuration
- Provides clear error messages if misconfigured
- Is consistent with how LiveTable already handles `:repo` and `:pubsub` configuration

## Changes Made

### 1. **Fixed export_helpers.ex** (line 108)
```elixir
# Before
app_name = Mix.Project.config()[:app]

# After
app_name = Application.fetch_env!(:live_table, :app)
```

### 2. **Updated Installer** (lib/mix/tasks/live_table.install.ex)
- Automatically adds `:app` configuration when running `mix live_table.install`
- New installations will work correctly out of the box

### 3. **Updated Documentation**
- README.md: Added `:app` to Basic Configuration section
- docs/configuration.md: Added `:app` to Required Configuration sections
- All configuration examples now include the `:app` parameter

## Configuration Required

Users will need to add `:app` to their LiveTable configuration:

```elixir
config :live_table,
  repo: YourApp.Repo,
  pubsub: YourApp.PubSub,
  app: :your_app  # Required for exports to work correctly
```

For new installations, the installer handles this automatically.

## Testing

The fix ensures exports work correctly in:
- [x] Development environment
- [x] Production with Mix available
- [x] Compiled releases without Mix

## Breaking Change Note

This requires existing users to add the `:app` configuration parameter, but this is necessary to fix the runtime bug and ensure exports work in production releases.